### PR TITLE
[fix]権限の有無によるページ閲覧制限

### DIFF
--- a/sksk_app/utils/auth.py
+++ b/sksk_app/utils/auth.py
@@ -29,7 +29,7 @@ class UserManager:
         new_user = User(
             name = name,
             email = email,
-            password = password,
+            password = generate_password_hash(password, method='sha256'),
             edit = edit,
             check = check,
             approve = approve,

--- a/sksk_app/views/admin.py
+++ b/sksk_app/views/admin.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, redirect, url_for, render_template, \
-    request, flash
+    request, flash, session
 from flask_login import login_required
 from sqlalchemy import not_
 from sksk_app import db
@@ -8,6 +8,14 @@ from sksk_app.models import User, Process
 from sksk_app.utils.auth import UserManager
 
 admin = Blueprint('admin', __name__, url_prefix='/admin')
+
+@admin.before_request
+def load_logged_in_user():
+    admin = session.get('admin')
+
+    if not admin:
+        flash('アクセスが許可されていません')
+        return redirect(url_for('pg.toppage'))
 
 @admin.route('/')
 @login_required

--- a/sksk_app/views/auth.py
+++ b/sksk_app/views/auth.py
@@ -9,21 +9,6 @@ from sksk_app.utils.auth import UserManager
 
 auth = Blueprint('auth', __name__, url_prefix='/auth')
 
-# @auth.before_app_request
-# def load_logged_in_user():
-#     user_id = session.get('user_id')
-
-#     if user_id is None:
-#         g.user = None
-#     else:
-#         user = db.session.get(User, user_id)
-#         user_list = {
-#             'email':user.email,
-#             'name':user.name,
-#             'password':user.password
-#         }
-#         g.user = user_list
-
 @auth.route('/signup')
 def signup():
     page_title = 'ユーザー登録'
@@ -71,6 +56,8 @@ def login():
         session['user_id'] = user.id
         session['user_name'] = user.name
         session['edit'] = user.edit
+        session['check'] = user.check
+        session['approve'] = user.approve
         session['admin'] = user.admin
         return redirect(url_for('pg.toppage'))
 

--- a/sksk_app/views/edit.py
+++ b/sksk_app/views/edit.py
@@ -1,5 +1,5 @@
 from flask import Blueprint, redirect, url_for, render_template, request, \
-    flash
+    flash, session
 from flask_login import login_required
 from sqlalchemy import func
 
@@ -7,6 +7,14 @@ from sksk_app import db
 from sksk_app.models import Level
 
 edit = Blueprint('edit', __name__, url_prefix='/edit')
+
+@edit.before_request
+def load_logged_in_user():
+    edit = session.get('edit')
+
+    if not edit:
+        flash('アクセスが許可されていません')
+        return redirect(url_for('pg.toppage'))
 
 
 @edit.route('/index')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -23,6 +23,9 @@ def app():
         password = '1234'
         UserManager.register_user(name, email, password)
         UserManager.add_privilege(1, 1)
+        UserManager.add_privilege(1, 2)
+        UserManager.add_privilege(1, 3)
+        UserManager.add_privilege(1, 4)
         
         db.session.begin_nested()
 


### PR DESCRIPTION
Close #34

編集、管理権限などをログインの時点でsessionに保存し、
編集・管理画面でbefore_requestを使用し権限の有無を確認、
権限がない場合はトップページにリダイレクトし、
「アクセスが許可されていません」と表示するようにしました。

それに伴いcontfest.pyにてダミーユーザーを登録する際、
全ての権限を付与しました。
権限がない場合のテストも必要になるかと思います。