### PR TITLE
[add]問題文から単語を抽出して登録

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,8 @@ flask-sqlalchemy = "*"
 flask-login = "*"
 pytest = "*"
 coverage = "*"
+konlpy = "*"
+mecab-python3 = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "06f1ef2e712621a3004f32978fd69665e5cb301562497a890716a4040e454aaa"
+            "sha256": "130f8dcfbe93d6b627b8429c45139d40155e1d9ebf6eab325940c48ad76a5785"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -100,11 +100,11 @@
         },
         "flask": {
             "hashes": [
-                "sha256:642c450d19c4ad482f96729bd2a8f6d32554aa1e231f4f6b4e7e5264b16cca2b",
-                "sha256:b9c46cc36662a7949f34b52d8ec7bb59c0d74ba08ba6cb9ce9adc1d8676d9526"
+                "sha256:7eb373984bf1c770023fce9db164ed0c3353cd0b53f130f4693da0ca756a2e6d",
+                "sha256:c0bec9477df1cb867e5a67c9e1ab758de9cb4a3e52dd70681f59fa40a62b3f2d"
             ],
             "index": "pypi",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "flask-login": {
             "hashes": [
@@ -220,6 +220,123 @@
             "markers": "python_version >= '3.7'",
             "version": "==3.1.2"
         },
+        "jpype1": {
+            "hashes": [
+                "sha256:000556d5839ffbe61c12f1fa41cbfd4e9a0abe103e0100febacc069d75defa8f",
+                "sha256:0099e77c6e99af13089b1c89cd99681b485fbf74daa492ee38e35d90d6349ffc",
+                "sha256:04ea4be3e9471bf62ccdeccc2417ad6b9a300effcc0e5f6af9534eafa14e3978",
+                "sha256:213f7154a7cc859dead7143cfee255bd3ce57938e0a5f2250b6768af0cef62c8",
+                "sha256:233a6a1a9c7f3633e7d74c14039f7ea35df81e138241f1acc8f94f65a8bd086e",
+                "sha256:24e601a31fb3b44decd5389ea87cbc39aaa0c61980c39b060561f9dc604f4cc5",
+                "sha256:34373696c3457f1d686639d928ef53b6a121203d9c0e651ed44dd3adf78bedb3",
+                "sha256:5473a89d2cab327e38382fd69d1209517bad44158fb3ee9e699ebfeb5bc1cd51",
+                "sha256:5d960ce12c3913242f9e4a11e55afa9c38e1a5410d0a38cc5a21086415c38a02",
+                "sha256:6089cd28067d77e5b4a09e272525ecd70f838b92a7c08d91d4fa7d192ec3f3bb",
+                "sha256:7039db1a522af55cf89f6a4a72120f8b074abcde2535543da34616640ecbb3c1",
+                "sha256:7622d07408e6d9a89e9eb70d4a9a675e51d5411657ac434ccec23cc94b828d9c",
+                "sha256:8692a7b14e807b224673010a648ab12415d3bc32323e351f03e6c64814ee319b",
+                "sha256:8c2fef2d0c298c8e69b2880ff866fa5db5f477ddd78ef310a357d697362c9f89",
+                "sha256:8d94013dfed3d1c7ee193e86393b2aea756a9910d222b7167ed493f9a0b1b3d5",
+                "sha256:9ce364d26ccbf7a21e35737f62663ce8d3aeb4e4b0f05d7e71f6126a6eb81059",
+                "sha256:b9e29a0ea763c16d0fb05528785d4ed0fa56a421d600eca87e43398b569d2dea",
+                "sha256:bd8bd76bf8741fa20d44ded776e6a3ea7fe103bcab7156f53ba7a72c50b7dd2f",
+                "sha256:d483a6c3e6cb19065e71d322c4742efcfafc44bf1a67ef8ef75f78626158c3d9",
+                "sha256:d85489a27c58b1b21feb8601406319b6a51d233ae9fa27de9b24c4dfea560b22",
+                "sha256:dc8ee854073474ad79ae168d90c2f6893854f58936cfa18f3587cadae0d3696d"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.4.1"
+        },
+        "konlpy": {
+            "hashes": [
+                "sha256:0b7928059e20eb1c72f6fe65a3d12c104fae9e68173904e16beef869cf0ea590"
+            ],
+            "index": "pypi",
+            "version": "==0.6.0"
+        },
+        "lxml": {
+            "hashes": [
+                "sha256:01d36c05f4afb8f7c20fd9ed5badca32a2029b93b1750f571ccc0b142531caf7",
+                "sha256:04876580c050a8c5341d706dd464ff04fd597095cc8c023252566a8826505726",
+                "sha256:05ca3f6abf5cf78fe053da9b1166e062ade3fa5d4f92b4ed688127ea7d7b1d03",
+                "sha256:090c6543d3696cbe15b4ac6e175e576bcc3f1ccfbba970061b7300b0c15a2140",
+                "sha256:0dc313ef231edf866912e9d8f5a042ddab56c752619e92dfd3a2c277e6a7299a",
+                "sha256:0f2b1e0d79180f344ff9f321327b005ca043a50ece8713de61d1cb383fb8ac05",
+                "sha256:13598ecfbd2e86ea7ae45ec28a2a54fb87ee9b9fdb0f6d343297d8e548392c03",
+                "sha256:16efd54337136e8cd72fb9485c368d91d77a47ee2d42b057564aae201257d419",
+                "sha256:1ab8f1f932e8f82355e75dda5413a57612c6ea448069d4fb2e217e9a4bed13d4",
+                "sha256:223f4232855ade399bd409331e6ca70fb5578efef22cf4069a6090acc0f53c0e",
+                "sha256:2455cfaeb7ac70338b3257f41e21f0724f4b5b0c0e7702da67ee6c3640835b67",
+                "sha256:2899456259589aa38bfb018c364d6ae7b53c5c22d8e27d0ec7609c2a1ff78b50",
+                "sha256:2a29ba94d065945944016b6b74e538bdb1751a1db6ffb80c9d3c2e40d6fa9894",
+                "sha256:2a87fa548561d2f4643c99cd13131acb607ddabb70682dcf1dff5f71f781a4bf",
+                "sha256:2e430cd2824f05f2d4f687701144556646bae8f249fd60aa1e4c768ba7018947",
+                "sha256:36c3c175d34652a35475a73762b545f4527aec044910a651d2bf50de9c3352b1",
+                "sha256:3818b8e2c4b5148567e1b09ce739006acfaa44ce3156f8cbbc11062994b8e8dd",
+                "sha256:3ab9fa9d6dc2a7f29d7affdf3edebf6ece6fb28a6d80b14c3b2fb9d39b9322c3",
+                "sha256:3efea981d956a6f7173b4659849f55081867cf897e719f57383698af6f618a92",
+                "sha256:4c8f293f14abc8fd3e8e01c5bd86e6ed0b6ef71936ded5bf10fe7a5efefbaca3",
+                "sha256:5344a43228767f53a9df6e5b253f8cdca7dfc7b7aeae52551958192f56d98457",
+                "sha256:58bfa3aa19ca4c0f28c5dde0ff56c520fbac6f0daf4fac66ed4c8d2fb7f22e74",
+                "sha256:5b4545b8a40478183ac06c073e81a5ce4cf01bf1734962577cf2bb569a5b3bbf",
+                "sha256:5f50a1c177e2fa3ee0667a5ab79fdc6b23086bc8b589d90b93b4bd17eb0e64d1",
+                "sha256:63da2ccc0857c311d764e7d3d90f429c252e83b52d1f8f1d1fe55be26827d1f4",
+                "sha256:6749649eecd6a9871cae297bffa4ee76f90b4504a2a2ab528d9ebe912b101975",
+                "sha256:6804daeb7ef69e7b36f76caddb85cccd63d0c56dedb47555d2fc969e2af6a1a5",
+                "sha256:689bb688a1db722485e4610a503e3e9210dcc20c520b45ac8f7533c837be76fe",
+                "sha256:699a9af7dffaf67deeae27b2112aa06b41c370d5e7633e0ee0aea2e0b6c211f7",
+                "sha256:6b418afe5df18233fc6b6093deb82a32895b6bb0b1155c2cdb05203f583053f1",
+                "sha256:76cf573e5a365e790396a5cc2b909812633409306c6531a6877c59061e42c4f2",
+                "sha256:7b515674acfdcadb0eb5d00d8a709868173acece5cb0be3dd165950cbfdf5409",
+                "sha256:7b770ed79542ed52c519119473898198761d78beb24b107acf3ad65deae61f1f",
+                "sha256:7d2278d59425777cfcb19735018d897ca8303abe67cc735f9f97177ceff8027f",
+                "sha256:7e91ee82f4199af8c43d8158024cbdff3d931df350252288f0d4ce656df7f3b5",
+                "sha256:821b7f59b99551c69c85a6039c65b75f5683bdc63270fec660f75da67469ca24",
+                "sha256:822068f85e12a6e292803e112ab876bc03ed1f03dddb80154c395f891ca6b31e",
+                "sha256:8340225bd5e7a701c0fa98284c849c9b9fc9238abf53a0ebd90900f25d39a4e4",
+                "sha256:85cabf64adec449132e55616e7ca3e1000ab449d1d0f9d7f83146ed5bdcb6d8a",
+                "sha256:880bbbcbe2fca64e2f4d8e04db47bcdf504936fa2b33933efd945e1b429bea8c",
+                "sha256:8d0b4612b66ff5d62d03bcaa043bb018f74dfea51184e53f067e6fdcba4bd8de",
+                "sha256:8e20cb5a47247e383cf4ff523205060991021233ebd6f924bca927fcf25cf86f",
+                "sha256:925073b2fe14ab9b87e73f9a5fde6ce6392da430f3004d8b72cc86f746f5163b",
+                "sha256:998c7c41910666d2976928c38ea96a70d1aa43be6fe502f21a651e17483a43c5",
+                "sha256:9b22c5c66f67ae00c0199f6055705bc3eb3fcb08d03d2ec4059a2b1b25ed48d7",
+                "sha256:9f102706d0ca011de571de32c3247c6476b55bb6bc65a20f682f000b07a4852a",
+                "sha256:a08cff61517ee26cb56f1e949cca38caabe9ea9fbb4b1e10a805dc39844b7d5c",
+                "sha256:a0a336d6d3e8b234a3aae3c674873d8f0e720b76bc1d9416866c41cd9500ffb9",
+                "sha256:a35f8b7fa99f90dd2f5dc5a9fa12332642f087a7641289ca6c40d6e1a2637d8e",
+                "sha256:a38486985ca49cfa574a507e7a2215c0c780fd1778bb6290c21193b7211702ab",
+                "sha256:a5da296eb617d18e497bcf0a5c528f5d3b18dadb3619fbdadf4ed2356ef8d941",
+                "sha256:a6e441a86553c310258aca15d1c05903aaf4965b23f3bc2d55f200804e005ee5",
+                "sha256:a82d05da00a58b8e4c0008edbc8a4b6ec5a4bc1e2ee0fb6ed157cf634ed7fa45",
+                "sha256:ab323679b8b3030000f2be63e22cdeea5b47ee0abd2d6a1dc0c8103ddaa56cd7",
+                "sha256:b1f42b6921d0e81b1bcb5e395bc091a70f41c4d4e55ba99c6da2b31626c44892",
+                "sha256:b23e19989c355ca854276178a0463951a653309fb8e57ce674497f2d9f208746",
+                "sha256:b264171e3143d842ded311b7dccd46ff9ef34247129ff5bf5066123c55c2431c",
+                "sha256:b26a29f0b7fc6f0897f043ca366142d2b609dc60756ee6e4e90b5f762c6adc53",
+                "sha256:b64d891da92e232c36976c80ed7ebb383e3f148489796d8d31a5b6a677825efe",
+                "sha256:b9cc34af337a97d470040f99ba4282f6e6bac88407d021688a5d585e44a23184",
+                "sha256:bc718cd47b765e790eecb74d044cc8d37d58562f6c314ee9484df26276d36a38",
+                "sha256:be7292c55101e22f2a3d4d8913944cbea71eea90792bf914add27454a13905df",
+                "sha256:c83203addf554215463b59f6399835201999b5e48019dc17f182ed5ad87205c9",
+                "sha256:c9ec3eaf616d67db0764b3bb983962b4f385a1f08304fd30c7283954e6a7869b",
+                "sha256:ca34efc80a29351897e18888c71c6aca4a359247c87e0b1c7ada14f0ab0c0fb2",
+                "sha256:ca989b91cf3a3ba28930a9fc1e9aeafc2a395448641df1f387a2d394638943b0",
+                "sha256:d02a5399126a53492415d4906ab0ad0375a5456cc05c3fc0fc4ca11771745cda",
+                "sha256:d17bc7c2ccf49c478c5bdd447594e82692c74222698cfc9b5daae7ae7e90743b",
+                "sha256:d5bf6545cd27aaa8a13033ce56354ed9e25ab0e4ac3b5392b763d8d04b08e0c5",
+                "sha256:d6b430a9938a5a5d85fc107d852262ddcd48602c120e3dbb02137c83d212b380",
+                "sha256:da248f93f0418a9e9d94b0080d7ebc407a9a5e6d0b57bb30db9b5cc28de1ad33",
+                "sha256:da4dd7c9c50c059aba52b3524f84d7de956f7fef88f0bafcf4ad7dde94a064e8",
+                "sha256:df0623dcf9668ad0445e0558a21211d4e9a149ea8f5666917c8eeec515f0a6d1",
+                "sha256:e5168986b90a8d1f2f9dc1b841467c74221bd752537b99761a93d2d981e04889",
+                "sha256:efa29c2fe6b4fdd32e8ef81c1528506895eca86e1d8c4657fda04c9b3786ddf9",
+                "sha256:f1496ea22ca2c830cbcbd473de8f114a320da308438ae65abad6bab7867fe38f",
+                "sha256:f49e52d174375a7def9915c9f06ec4e569d235ad428f70751765f48d5926678c"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
+            "version": "==4.9.2"
+        },
         "markupsafe": {
             "hashes": [
                 "sha256:0576fe974b40a400449768941d5d0858cc624e3249dfd1e0c33674e5c7ca7aed",
@@ -276,6 +393,35 @@
             "markers": "python_version >= '3.7'",
             "version": "==2.1.2"
         },
+        "mecab-python3": {
+            "hashes": [
+                "sha256:023cfd4efa26fc61563ee185e8ac3d5fcdffcaba01931bbae34aa0ec06814875",
+                "sha256:0fb9f5a06f9cd9c5724608956128b91f5330248a78e9de322a0abd5beaba24a3",
+                "sha256:16f38ace484020bd3446a10054829678c1e7b97f1740b58b00a31d595cff025e",
+                "sha256:2958a94ee7ed521e95c333a7b66adcead9973db3d4f4873789c425d41726e52c",
+                "sha256:30177272efa6ba26909b540e3816659c9f93ee49a5cc2b8ea47c17eff05c686b",
+                "sha256:3eb8655d4eb7e17dbe7f409b8dda327539de9ee8cf06ebe338aa595bb597b53d",
+                "sha256:68334cbc6e0442ccd57770137ece585de9a512f01405bd2ad074fd28578180f8",
+                "sha256:6c99ec5f5581e4b56c8b68b4eeac4c6b59c6de12e66a2cfe4b1c6f8e87d38bd7",
+                "sha256:849aa7cfb828f0fb65340666fb2ae281855f5319699291121e116f43f478401c",
+                "sha256:8f0c5fe224c28ebd6fad2199be129755246091310de71eb9a43d88473d5b8950",
+                "sha256:9c3eeb4adf864a74ced9a1c5443b174f1e851323143ca6f24391fb6db8d44110",
+                "sha256:a455f0f1830392548366aae56819a22fa0f5786c39c4cf6cf84fe438a5fc7cbc",
+                "sha256:b2a3b6243d709ccf6672d54c9c17cb6281a17737626caaafb0219944835d6b9c",
+                "sha256:b56692cef89cd8ad0179bd2f989e4b3209686eb59124e0191167d9a3e64cd1a0",
+                "sha256:b8c995629aeb6bdddf37eee1c4049549ff1993e3888e28eb6cc59c8dce79de41",
+                "sha256:c80e58dcc90da095b64799950046dc4b9db3fb6bf30a8f817d1639cdaf601ba1",
+                "sha256:d1061bcd3d5567d6522e8794773689e6f9dedadcd3d3b1652893142f6334ec95",
+                "sha256:e00f0c329c7708b6cf5e5b2b1772535de3d6d69f99e6105a1acf40b94c62afe5",
+                "sha256:e049805f8342020b559357f4ea2b69b7d4faf8681c979ffd868d4d25d3a89021",
+                "sha256:e28997040b5ea9df3cf8969c5d28e7ba730ef4f924badac0548cd14383e56c66",
+                "sha256:ef43e4ab82396d1a59f4d8e2237c4136e09391e8e8ba623af4b52e6b52377fdd",
+                "sha256:fd10ba05f94dea7fe5e281336b7a4d07f79062c25139077d935833d0db303450",
+                "sha256:fde76ebc2fcf4f375b520a706af316f88be304302f5e5d36105992a1ecd3ea1b"
+            ],
+            "index": "pypi",
+            "version": "==1.0.6"
+        },
         "mysql-connector-python": {
             "hashes": [
                 "sha256:145aeb75eefb7425e0a7fb36a4f95ebfe79e06be7c69a4045d34cde95c666dc4",
@@ -306,6 +452,40 @@
             ],
             "index": "pypi",
             "version": "==8.0.32"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:003a9f530e880cb2cd177cba1af7220b9aa42def9c4afc2a2fc3ee6be7eb2b22",
+                "sha256:150947adbdfeceec4e5926d956a06865c1c690f2fd902efede4ca6fe2e657c3f",
+                "sha256:2620e8592136e073bd12ee4536149380695fbe9ebeae845b81237f986479ffc9",
+                "sha256:2eabd64ddb96a1239791da78fa5f4e1693ae2dadc82a76bc76a14cbb2b966e96",
+                "sha256:4173bde9fa2a005c2c6e2ea8ac1618e2ed2c1c6ec8a7657237854d42094123a0",
+                "sha256:4199e7cfc307a778f72d293372736223e39ec9ac096ff0a2e64853b866a8e18a",
+                "sha256:4cecaed30dc14123020f77b03601559fff3e6cd0c048f8b5289f4eeabb0eb281",
+                "sha256:557d42778a6869c2162deb40ad82612645e21d79e11c1dc62c6e82a2220ffb04",
+                "sha256:63e45511ee4d9d976637d11e6c9864eae50e12dc9598f531c035265991910468",
+                "sha256:6524630f71631be2dabe0c541e7675db82651eb998496bbe16bc4f77f0772253",
+                "sha256:76807b4063f0002c8532cfeac47a3068a69561e9c8715efdad3c642eb27c0756",
+                "sha256:7de8fdde0003f4294655aa5d5f0a89c26b9f22c0a58790c38fae1ed392d44a5a",
+                "sha256:889b2cc88b837d86eda1b17008ebeb679d82875022200c6e8e4ce6cf549b7acb",
+                "sha256:92011118955724465fb6853def593cf397b4a1367495e0b59a7e69d40c4eb71d",
+                "sha256:97cf27e51fa078078c649a51d7ade3c92d9e709ba2bfb97493007103c741f1d0",
+                "sha256:9a23f8440561a633204a67fb44617ce2a299beecf3295f0d13c495518908e910",
+                "sha256:a51725a815a6188c662fb66fb32077709a9ca38053f0274640293a14fdd22978",
+                "sha256:a77d3e1163a7770164404607b7ba3967fb49b24782a6ef85d9b5f54126cc39e5",
+                "sha256:adbdce121896fd3a17a77ab0b0b5eedf05a9834a18699db6829a64e1dfccca7f",
+                "sha256:c29e6bd0ec49a44d7690ecb623a8eac5ab8a923bce0bea6293953992edf3a76a",
+                "sha256:c72a6b2f4af1adfe193f7beb91ddf708ff867a3f977ef2ec53c0ffb8283ab9f5",
+                "sha256:d0a2db9d20117bf523dde15858398e7c0858aadca7c0f088ac0d6edd360e9ad2",
+                "sha256:e3ab5d32784e843fc0dd3ab6dcafc67ef806e6b6828dc6af2f689be0eb4d781d",
+                "sha256:e428c4fbfa085f947b536706a2fc349245d7baa8334f0c5723c56a10595f9b95",
+                "sha256:e8d2859428712785e8a8b7d2b3ef0a1d1565892367b32f915c4a4df44d0e64f5",
+                "sha256:eef70b4fc1e872ebddc38cddacc87c19a3709c0e3e5d20bf3954c147b1dd941d",
+                "sha256:f64bb98ac59b3ea3bf74b02f13836eb2e24e48e0ab0145bbda646295769bd780",
+                "sha256:f9006288bcf4895917d02583cf3411f98631275bc67cce355a7f39f8c14338fa"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==1.24.2"
         },
         "packaging": {
             "hashes": [
@@ -361,50 +541,50 @@
         },
         "sqlalchemy": {
             "hashes": [
-                "sha256:004459a78d376ab9c79ac1b613e0f0d44e88a105e4232357d0c7fa4c7b7e3a49",
-                "sha256:061c7be6b7042f298187e39528c85b4de233361412c88de9fba62a3ee727eb71",
-                "sha256:0666025f44119bd18e1c5ceb536422356dc176d3230a13979ab2a7dd5d24b899",
-                "sha256:0c6c556e01b0bbaea85ce030af4347e47fcb695c3254cfd480099ec1ed6ea609",
-                "sha256:1a9d46844f4c88dc6cbfcabc6985beebd34661ef3b0e75c216a6428939fb3669",
-                "sha256:27e8a5359c6227f3d665b1556169de840b375cf055c800a9bc27ed33f3c51e1b",
-                "sha256:293c51d60da2ad52fb88d3f2357ff7ac3c156c5cb81feadd8258d45ebeea0a65",
-                "sha256:301f5fb0718e000d47db6ebcee64de91fa94865d7b59872258ba36e4eafbfe8f",
-                "sha256:3381fa42e2b388abf448800cf550bbf174eff41f6c57b362077db142417d2922",
-                "sha256:35765bf1ff823d05cf9c4eb18ba2db2290b2a2e2196d1a1d06d714ea55c1b997",
-                "sha256:38ab55db6ce10c1ab2424d1dfed0add6e6afdeb1c65cec776ac6a01c1fb2f90a",
-                "sha256:3b79ab1b7f5c39050daa03c100115efa2d8f996f14bc33cc9535cb60ca8357c4",
-                "sha256:43482b8f0bed711b3769037e86c45619370bf529aee605975586fdd80ee770a0",
-                "sha256:4b1f661cc378d61f495af49d8af83f779bb802046394e63ab1269b4180fceba0",
-                "sha256:55a72010983b655a638ea318b4efa30b04b001c158298ceb47fbf5da296092b0",
-                "sha256:5d34374993910d4520681b7b95ea60e05aa18a8ef7d36ffa94bde87730f6426d",
-                "sha256:5e8baa4e421136a582f5d9d262ce568ce3eb413d3455650c34d674e5a9f092aa",
-                "sha256:6282a712dbcfd86e3fee2e4c459c7337141f774450f60809fd0f0edebd07f37a",
-                "sha256:8a3bd94c7d04fed688ba333bfb5a0106800112b9f623aed1e5b0b6466e8c5c66",
-                "sha256:8f3e9b71425af186fa51ab0d6172ef81809eb0e9f89b035612a913f8a9b44e4b",
-                "sha256:90550ff7a96143579472a93aff6dae0999316528ce0f3165083f93d036e313bf",
-                "sha256:92dc029273615ffbb40fa0e1cc8190618f1603ad98b1ad59d57078f1feb969b9",
-                "sha256:9a9205379388e57c486244e285d5d5c047ef9241bd4238e9469a4873b75d1e4a",
-                "sha256:9e28dc39dd739f48d38486811f5a703673ed11e5968402fff835e60cbf379833",
-                "sha256:abeb371ff47633c7d16b1e1e56e3d41a9b0ab34463c1726f22e1b68401d28cac",
-                "sha256:afd9326886d424616f6c1b90d99b58c8a99c51f4515c8f8550830f9d4ac04ef3",
-                "sha256:b0323d65b4cd9408261026495a650566d62d056adeb848d1f1f8be0da38a1e0a",
-                "sha256:b80ddc3bf6088ce83437cdfb2e32099b82a2819c409c85b782a84aa1143f8eda",
-                "sha256:ba1ec69fa7abb23c2bc9fcd10b3386ea1f62f9d558b7f3a749988374e6cb6ee5",
-                "sha256:bfac4cb8585d7c5b06567c754e999410eb12248f8ce2474dc2d9bc53be1fba0c",
-                "sha256:c7892245a79d612e163d2ce72b1e77c863840f7453e9469f6dd3e6b9ded67739",
-                "sha256:d561e44c0b480b7e74fa002bea949c9f5aff555724f4d10883391cbd8790c81b",
-                "sha256:d8efcdfe08efd12ee91f5e858adb34a0a73071a95c09c47303a656a9bac3b93b",
-                "sha256:dd3595576c6cdfd91eb1aaa18f542e9db87b5a5f3552573892d37d91102fd951",
-                "sha256:e4d3cf5352f724237e27463de4bf19888235342af2efa37ef1cd391d8b702a16",
-                "sha256:ebf6fe4cfd3b79f582b750b7ba69ba779d3fc7498818f8251dc6d38f5d5e206f",
-                "sha256:edf1a0cfd9979a805ad0d725e436d6460a5b44afc7de0ffae3321a9d2afeff54",
-                "sha256:f2acafb0ef17d591a13621581b5d1abddb3dd25f601f368173135922915f56cd",
-                "sha256:f91a4d0815fa9d236380a27762f7bd1304631605b8e2aa75b6b7d03343fd8fe8",
-                "sha256:fc486297fe7f1465a2baac371d2153643a34ea1af803b68443bc359cfdc2bbcf",
-                "sha256:fec1aebc9256b02a59e8a69d4b7aa2299e04e7b51bb4fd11daaba5df1ad592c7"
+                "sha256:011ef3c33f30bae5637c575f30647e0add98686642d237f0c3a1e3d9b35747fa",
+                "sha256:0adca8a3ca77234a142c5afed29322fb501921f13d1d5e9fa4253450d786c160",
+                "sha256:1644c603558590f465b3fa16e4557d87d3962bc2c81fd7ea85b582ecf4676b31",
+                "sha256:2267c004e78e291bba0dc766a9711c389649cf3e662cd46eec2bc2c238c637bd",
+                "sha256:25e4e54575f9d2af1eab82d3a470fca27062191c48ee57b6386fe09a3c0a6a33",
+                "sha256:2a2f9120eb32190bdba31d1022181ef08f257aed4f984f3368aa4e838de72bc0",
+                "sha256:2c82395e2925639e6d320592943608070678e7157bd1db2672a63be9c7889434",
+                "sha256:3f927340b37fe65ec42e19af7ce15260a73e11c6b456febb59009bfdfec29a35",
+                "sha256:54aa9f40d88728dd058e951eeb5ecc55241831ba4011e60c641738c1da0146b7",
+                "sha256:57dcd9eed52413f7270b22797aa83c71b698db153d1541c1e83d45ecdf8e95e7",
+                "sha256:582053571125895d008d4b8d9687d12d4bd209c076cdbab3504da307e2a0a2bd",
+                "sha256:59cf0cdb29baec4e074c7520d7226646a8a8f856b87d8300f3e4494901d55235",
+                "sha256:6363697c938b9a13e07f1bc2cd433502a7aa07efd55b946b31d25b9449890621",
+                "sha256:662a79e80f3e9fe33b7861c19fedf3d8389fab2413c04bba787e3f1139c22188",
+                "sha256:67901b91bf5821482fcbe9da988cb16897809624ddf0fde339cd62365cc50032",
+                "sha256:679b9bd10bb32b8d3befed4aad4356799b6ec1bdddc0f930a79e41ba5b084124",
+                "sha256:738c80705e11c1268827dbe22c01162a9cdc98fc6f7901b429a1459db2593060",
+                "sha256:77a380bf8721b416782c763e0ff66f80f3b05aee83db33ddfc0eac20bcb6791f",
+                "sha256:77d05773d5c79f2d3371d81697d54ee1b2c32085ad434ce9de4482e457ecb018",
+                "sha256:817aab80f7e8fe581696dae7aaeb2ceb0b7ea70ad03c95483c9115970d2a9b00",
+                "sha256:81f1ea264278fcbe113b9a5840f13a356cb0186e55b52168334124f1cd1bc495",
+                "sha256:8a88b32ce5b69d18507ffc9f10401833934ebc353c7b30d1e056023c64f0a736",
+                "sha256:8ff0a7c669ec7cdb899eae7e622211c2dd8725b82655db2b41740d39e3cda466",
+                "sha256:918c2b553e3c78268b187f70983c9bc6f91e451a4f934827e9c919e03d258bd7",
+                "sha256:954f1ad73b78ea5ba5a35c89c4a5dfd0f3a06c17926503de19510eb9b3857bde",
+                "sha256:95a18e1a6af2114dbd9ee4f168ad33070d6317e11bafa28d983cc7b585fe900b",
+                "sha256:9946ee503962859f1a9e1ad17dff0859269b0cb453686747fe87f00b0e030b34",
+                "sha256:9a7ecaf90fe9ec8e45c86828f4f183564b33c9514e08667ca59e526fea63893a",
+                "sha256:a42e6831e82dfa6d16b45f0c98c69e7b0defc64d76213173456355034450c414",
+                "sha256:b01dce097cf6f145da131a53d4cce7f42e0bfa9ae161dd171a423f7970d296d0",
+                "sha256:b5deafb4901618b3f98e8df7099cd11edd0d1e6856912647e28968b803de0dae",
+                "sha256:b67d6e626caa571fb53accaac2fba003ef4f7317cb3481e9ab99dad6e89a70d6",
+                "sha256:c1e8edc49b32483cd5d2d015f343e16be7dfab89f4aaf66b0fa6827ab356880d",
+                "sha256:c621f05859caed5c0aab032888a3d3bde2cae3988ca151113cbecf262adad976",
+                "sha256:ce54965a94673a0ebda25e7c3a05bf1aa74fd78cc452a1a710b704bf73fb8402",
+                "sha256:d8efdda920988bcade542f53a2890751ff680474d548f32df919a35a21404e3f",
+                "sha256:dc7b9f55c2f72c13b2328b8a870ff585c993ba1b5c155ece5c9d3216fa4b18f6",
+                "sha256:dd801375f19a6e1f021dabd8b1714f2fdb91cbc835cd13b5dd0bd7e9860392d7",
+                "sha256:f342057422d6bcfdd4996e34cd5c7f78f7e500112f64b113f334cdfc6a0c593d",
+                "sha256:f696828784ab2c07b127bfd2f2d513f47ec58924c29cff5b19806ac37acee31c",
+                "sha256:fdb2686eb01f670cdc6c43f092e333ff08c1cf0b646da5256c1237dc4ceef4ae"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.0.2"
+            "version": "==2.0.4"
         },
         "tomli": {
             "hashes": [
@@ -416,27 +596,27 @@
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
-                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
+                "sha256:5cb5f4a79139d699607b3ef622a1dedafa84e115ab0024e0d9c044a9479ca7cb",
+                "sha256:fb33085c39dd998ac16d1431ebc293a8b3eedd00fd4a32de0ff79002c19511b4"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.4.0"
+            "version": "==4.5.0"
         },
         "werkzeug": {
             "hashes": [
-                "sha256:7ea2d48322cc7c0f8b3a215ed73eabd7b5d75d0b50e31ab006286ccff9e00b8f",
-                "sha256:f979ab81f58d7318e064e99c4506445d60135ac5cd2e177a2de0089bfd4c9bd5"
+                "sha256:2e1ccc9417d4da358b9de6f174e3ac094391ea1d4fbef2d667865d819dfd0afe",
+                "sha256:56433961bc1f12533306c624f3be5e744389ac61d722175d543e1751285da612"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.2.2"
+            "version": "==2.2.3"
         },
         "zipp": {
             "hashes": [
-                "sha256:6c4fe274b8f85ec73c37a8e4e3fa00df9fb9335da96fb789e3b96b318e5097b3",
-                "sha256:a3cac813d40993596b39ea9e93a18e8a2076d5c378b8bc88ec32ab264e04ad02"
+                "sha256:188834565033387710d046e3fe96acfc9b5e86cbca7f39ff69cf21a4128198b7",
+                "sha256:9e5421e176ef5ab4c0ad896624e87a7b2f07aca746c9b2aa305952800cb8eecb"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.12.1"
+            "version": "==3.14.0"
         }
     },
     "develop": {}

--- a/sksk_app/models.py
+++ b/sksk_app/models.py
@@ -133,20 +133,46 @@ class Question(db.Model):
     foreign_l = db.Column(db.String(100))
     style = db.Column(db.Integer, db.ForeignKey('style.id'))
     position = db.Column(db.Integer, default=1)
+    created_at = db.Column(db.DateTime, nullable=False)
+    created_by = db.Column(db.Integer, db.ForeignKey('user.id'))
+    checked = db.Column(db.Boolean, nullable=False, default=0)
     released = db.Column(db.Boolean, nullable=False,default=0)
 
 
-    def __init__(self, element=None, japanese=None,foreign_l=None, style=None, position=None, released=None):
+    def __init__(self, element=None, japanese=None,foreign_l=None, style=None, position=None, created_at=None, created_by=None, checked=None, released=None):
         self.element = element
         self.japanese = japanese
         self.foreign_l = foreign_l
         self.style = style
         self.position = position
+        self.created_at = created_at
+        self.created_by =created_by
+        self.checked = checked
         self.released = released
     
     def __repr__(self):
-        return '<Element id:{} element:{} japanese:{} foreign:{} style:{} position:{} released:{}>'.format(self.id, self.element, self.japanese, self.foreign_l, self.style, self.position, self.released)
+        return '<Element id:{} element:{} japanese:{} foreign:{} style:{} position:{} created_at:{} created_by:{} checked:{} released:{}>'.format(self.id, self.element, self.japanese, self.foreign_l, self.style, self.position, self.created_at, self.created_by, self.checked, self.released)
 
+class Question_Management(db.Model):
+    __tablename__  = 'question_management'
+    id = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    user = db.Column(db.Integer, db.ForeignKey('user.id'))
+    question = db.Column(db.Integer, db.ForeignKey('question.id'))
+    process = db.Column(db.Integer, db.ForeignKey('process.id'))
+    result = db.Column(db.Boolean, default=0)
+    message = db.Column(db.Text)
+    executed_at = db.Column(db.DateTime, nullable=False)
+
+    def __init__(self, user=None, question=None, process=None, result=None, message=None, executed_at=None):
+        self.user = user
+        self.question = question
+        self.process = process
+        self.result = result
+        self.message = message
+        self.executed_at = executed_at
+
+    def __repr__(self):
+        return '<Question_Management id:{} user:{} question:{} process:{} result:{} message:{} executed_at:{}>'.format(self.id)
 
 class Word(db.Model):
     __tablename__ = 'word'

--- a/sksk_app/script/database.py
+++ b/sksk_app/script/database.py
@@ -24,8 +24,6 @@ app.cli.add_command(create)
 def init():
     level = 'ハン検5級'
     QuestionManager.insert_level(level,None,None)
-    level = 'ハン検4級'
-    QuestionManager.insert_level(level,None,None)
 
     style = 'ハムニダ体'
     editor.StyleManager.add_style(style)

--- a/sksk_app/templates/edit/add_hint.html
+++ b/sksk_app/templates/edit/add_hint.html
@@ -1,0 +1,45 @@
+{%extends "base.html" %}
+{% block body %}
+
+<h2>ヒントの追加</h2>
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+<p>この単語を登録、ヒントに追加しますか？</p>
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td>{{j_word}}</td>
+        <td>{{f_word}}</td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td>{{question.id}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+    </tr>
+</table>
+
+<form action="{{url_for('edit.add_word_hint_execute')}}" method="POST">
+    <input type="hidden" name="question_id" value="{{question.id}}">
+    <input type="hidden" name="j_word" value="{{j_word}}">
+    <input type="hidden" name="f_word" value="{{f_word}}">
+    <button>追加</button>
+</form>
+
+
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+
+{% endblock %}

--- a/sksk_app/templates/edit/add_question.html
+++ b/sksk_app/templates/edit/add_question.html
@@ -24,16 +24,19 @@
 </table>
 <table>
     <tr>
-        <th>入力した文</th>
+        <th></th>
+        <th>日本語</th>
         <th>翻訳</th>
     </tr>
     <tr>
+        <th>原文</th>
         <td>{{question.japanese}}</td>
-        <td></td>
+        <td>{{question.foreign_l}}</td>
     </tr>
     <tr>
-        <td>{{question.foreign_l}}</td>
-        <td></td>
+        <th>翻訳</th>
+        <td>{{question.ko_to_ja}}</td>
+        <td>{{question.ja_to_ko}}</td>
     </tr>
 </table>
 

--- a/sksk_app/templates/edit/confirm_hint_f.html
+++ b/sksk_app/templates/edit/confirm_hint_f.html
@@ -1,0 +1,120 @@
+{%extends "base.html" %}
+{% block body %}
+
+<h2>{{f_word}}</h2>
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語(候補)</th>
+    </tr>
+    <tr>
+        <td>{{f_word}}</td>
+        <td>{{translated_word}}</td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td rowspan="2">{{question.id}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+    </tr>
+    <tr>
+        <td>
+            <div class="flex">
+            {% for word in question['word'] %}
+            <form action="{{url_for('edit.add_word_hint')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="j_word" value="{{word}}">
+                <input type="hidden" name="f_word" value="{{f_word}}">
+                <button>{{word}}</button>
+            </form>
+            {% endfor %}
+            </div>
+        </td>
+        <td>
+            <div class="flex">
+            {% for foword in question['foword'] %}
+            {% if not foword == '.' %}
+            <form action="{{url_for('edit.confirm_hint_f')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="f_word" value="{{foword}}">
+                <button>{{foword}}</button>
+            </form>
+            {% else %}
+            {% endif %}
+            {% endfor %}
+            </div>
+        </td>
+    </tr>
+</table>
+
+
+<h3>登録されているヒント</h3>
+
+{% if hint_existed %}
+<p style="color:red">登録されています。</p>
+{% endif %}
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    {% for word in words %}
+    <tr>
+        {% if f_word == word['foreign_l'] %}
+        <td style="color:red">{{word['japanese']}}</td>
+        {% else %}
+        <td>{{word['japanese']}}</td>
+        {% endif %}
+        {% if f_word == word['foreign_l'] %}
+        <td style="color:red">{{word['foreign_l']}}</td>
+        {% else %}
+        <td>{{word['foreign_l']}}</td>
+        {% endif %}
+    </tr>
+    {% endfor %}
+    {% if not words[0] %}
+    <tr>
+        <td colspan="2">登録ヒントなし</td>
+    </tr>
+    {% endif %}
+</table>
+
+<h3>登録されている単語</h3>
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+        <th>操作</th>
+    </tr>
+{% for f_word in f_words %}
+<tr>
+    <td>{{f_word['id']}}</td>
+    <td>{{f_word['japanese']}}</td>
+    <td>{{f_word['foreign_l']}}</td>
+    <td>追加する</td>
+</tr>
+{% endfor %}
+{% if not f_words[0] %}
+<tr>
+    <td colspan="4">登録単語なし</td>
+</tr>
+{% endif %}
+</table>
+
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+
+{% endblock %}

--- a/sksk_app/templates/edit/confirm_hint_j.html
+++ b/sksk_app/templates/edit/confirm_hint_j.html
@@ -1,0 +1,117 @@
+{%extends "base.html" %}
+{% block body %}
+
+<h2>{{j_word}}</h2>
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語(候補)</th>
+    </tr>
+    <tr>
+        <td>{{j_word}}</td>
+        <td>{{translated_word}}</td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td rowspan="2">{{question.id}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+    </tr>
+    <tr>
+        <td>
+            <div class="flex">
+            {% for word in question['word'] %}
+            <form action="{{url_for('edit.confirm_hint_j')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="j_word" value="{{word}}">
+                <button>{{word}}</button>
+            </form>
+            {% endfor %}
+            </div>
+        </td>
+        <td>
+            <div class="flex">
+            {% for foword in question['foword'] %}
+            {% if not foword == '.' %}
+            <form action="{{url_for('edit.add_word_hint')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="j_word" value="{{j_word}}"> 
+                <input type="hidden" name="f_word" value="{{foword}}">
+                <button>{{foword}}</button>
+            </form>
+            {% else %}
+            {% endif %}
+            {% endfor %}
+            </div>
+        </td>
+    </tr>
+</table>
+
+
+<h3>登録されているヒント</h3>
+
+{% if hint_existed %}
+<p style="color:red">登録されています。</p>
+{% endif %}
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    {% for word in words %}
+    <tr>
+        {% if j_word == word['japanese'] %}
+        <td style="color:red">{{word['japanese']}}</td>
+        {% else %}
+        <td>{{word['japanese']}}</td>
+        {% endif %}
+        
+        <td>{{word['foreign_l']}}</td>
+    </tr>
+    {% endfor %}
+    {% if not words[0] %}
+    <tr>
+        <td colspan="2">登録ヒントなし</td>
+    </tr>
+    {% endif %}
+</table>
+
+<h3>登録されている単語</h3>
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+        <th>操作</th>
+    </tr>
+{% for j_word in j_words %}
+<tr>
+    <td>{{j_word['id']}}</td>
+    <td>{{j_word['japanese']}}</td>
+    <td>{{j_word['foreign_l']}}</td>
+    <td>追加する</td>
+</tr>
+{% endfor %}
+{% if not j_words[0] %}
+<tr>
+    <td colspan="4">登録単語なし</td>
+</tr>
+{% endif %}
+</table>
+
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+
+{% endblock %}

--- a/sksk_app/templates/edit/index.html
+++ b/sksk_app/templates/edit/index.html
@@ -7,7 +7,7 @@
 
 
 <div class="flex">
-    <select name="l" id="level" onchange="location.href=value">
+    <select name="l" id="level1" onchange="location.href=value">
         {% for level in levels %}
         <option value="{{url_for('edit.index', l=level.id)}}">{{level.level}}</option>
         {% endfor %}
@@ -16,7 +16,7 @@
 <form action="{{url_for('edit.show_questions')}}" method="GET">
 
     
-    <select name="g" id="e_group">
+    <select name="g" id="e_group1">
         {% for e_group in e_groups %}
         <option value="{{e_group.id}}">{{e_group.e_group}}</option>
         {% endfor %}
@@ -25,10 +25,34 @@
 </div>
 </form>
 
+<div class="flex">
+    <select name="l" id="level2" onchange="location.href=value">
+        {% for level in levels %}
+        <option value="{{url_for('edit.index', l=level.id)}}">{{level.level}}</option>
+        {% endfor %}
+    </select> 
+
+<form action="{{url_for('edit.show_hints')}}" method="GET">
+
+    
+    <select name="g" id="e_group2">
+        {% for e_group in e_groups %}
+        <option value="{{e_group.id}}">{{e_group.e_group}}</option>
+        {% endfor %}
+    </select>
+    <button>ヒントの登録</button>
+</div>
+</form>
+<p>(少し時間がかかります。)</p>
+
+
+
+
 <script>
 
     let selected_level = '{{level_position}}' - 1;
-    document.getElementById("level").options[selected_level].selected = true;
+    document.getElementById("level1").options[selected_level].selected = true;
+    document.getElementById("level2").options[selected_level].selected = true;
 
 </script>
 

--- a/sksk_app/templates/edit/show_hints.html
+++ b/sksk_app/templates/edit/show_hints.html
@@ -1,0 +1,91 @@
+{% extends "base.html" %}
+{% block body %}
+
+<h2>ヒントの登録</h2>
+
+
+<p><a href="{{url_for('edit.show')}}">レベル・項目グループ・項目の登録</a></p>
+
+<div class="flex">
+    <select name="level" id="level" onchange="location.href=value">
+        {% for level in levels %}
+        <option value="{{url_for('edit.show_hints', l=level.id)}}">{{level.level}}</option>
+        {% endfor %}
+    </select> 
+    
+    <select name="e_group_id" id="e_group" onchange="location.href=value">
+        {% for e_group in e_groups %}
+        <option value="{{url_for('edit.show_hints',l=level_id,g=e_group.id)}}">{{e_group.e_group}}</option>
+        {% endfor %}
+    </select>
+
+    <select name="element_id" id="element" onchange="location.href=value">
+        {% for element in elements %}
+            <option value="{{url_for('edit.show_hints', e=element.id)}}">{{element.element}}</option>
+        {% endfor %}
+    </select>
+</div>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>外国語</th>
+        <th>ヒント</th>
+    </tr>
+    {% for question in questions %}
+    <tr>
+        <td rowspan="2">{{question.id}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+        <td rowspan="2">
+            {%for hint in question['hint'] %}
+                {{hint.japanese}}
+            {% endfor %}
+        </td>
+    </tr>
+    <tr>
+        <td>
+            <div class="flex">
+            {%for word in question['word'] %}
+            <form action="{{url_for('edit.confirm_hint_j')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="j_word" value="{{word}}">
+                <button>{{word}}</button>
+            </form>
+            {% endfor %}
+            </div>
+        </td>
+        <td>
+            <div class="flex">
+            {%for foword in question['foword'] %}
+            {% if not foword == '.' %}
+            <form action="{{url_for('edit.confirm_hint_f')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="f_word" value="{{foword}}">
+                <button>{{foword}}</button>
+            </form>
+            {% else %}
+            {% endif %}
+            {% endfor %}
+            </div>
+        </td>
+    </tr>
+
+    {% endfor %}
+</table>
+
+
+<p><a href="{{url_for('edit.index')}}">編集トップページ</a></p>
+
+<script>
+    
+    let selected_level = '{{level_position}}' - 1;
+    let selected_e_group = '{{e_group_position}}' - 1;
+    let selected_element = '{{element.position}}' - 1;
+    document.getElementById("level").options[selected_level].selected = true;
+    document.getElementById("e_group").options[selected_e_group].selected = true;
+    document.getElementById("element").options[selected_element].selected = true;
+
+</script>
+{%endblock%}

--- a/sksk_app/templates/edit/show_questions.html
+++ b/sksk_app/templates/edit/show_questions.html
@@ -19,9 +19,9 @@
         {% endfor %}
     </select>
 
-    <select name="element_id" id="element">
+    <select name="element_id" id="element" onchange="location.href=value">
         {% for element in elements %}
-            <option value="{{url_for('edit.show_questions')}}">{{element.element}}</option>
+            <option value="{{url_for('edit.show_questions', e=element.id)}}">{{element.element}}</option>
         {% endfor %}
     </select>
 </div>
@@ -81,10 +81,10 @@
     
     let selected_level = '{{level_position}}' - 1;
     let selected_e_group = '{{e_group_position}}' - 1;
-    // console.log(selected_e_group)
+    let selected_element = '{{element.position}}' - 1;
     document.getElementById("level").options[selected_level].selected = true;
-
     document.getElementById("e_group").options[selected_e_group].selected = true;
+    document.getElementById("element").options[selected_element].selected = true;
 
 </script>
 {%endblock%}

--- a/sksk_app/test_translation.py
+++ b/sksk_app/test_translation.py
@@ -1,0 +1,25 @@
+import MeCab
+from konlpy.tag import Mecab
+from konlpy.utils import pprint
+from konlpy.tag import Okt
+
+sample = '父は医者です。'
+mecab = MeCab.Tagger()
+# result = mecab.parse(sample)
+words = []
+i = 0
+node = mecab.parseToNode(sample)
+while node:
+    p = node.feature.split(',')[0]
+    if p == '名詞' or p == '動詞' or p== '形容詞' or p =='副詞':
+        words.append(node.feature.split(",")[6])
+    node = node.next
+
+print(words)
+
+sample = '어머니는 공무원입니다.'
+mecab = Mecab()
+pprint(mecab.pos(sample))
+
+okt = Okt()
+pprint(okt.morphs(sample, norm=False, stem=True))

--- a/sksk_app/utils/api.py
+++ b/sksk_app/utils/api.py
@@ -1,0 +1,40 @@
+import urllib.request
+import json
+import sksk_app.config as config
+
+class Papago:
+    def ja_to_ko(word):
+        client_id = config.NAVER_CLIENT_ID
+        client_secret = config.NAVER_CLIENT_SECRET
+        encText = urllib.parse.quote(word)
+        data = "source=ja&target=ko&text=" + encText
+        url = "https://openapi.naver.com/v1/papago/n2mt"
+        request = urllib.request.Request(url)
+        request.add_header("X-Naver-Client-Id",client_id)
+        request.add_header("X-Naver-Client-Secret",client_secret)
+        response = urllib.request.urlopen(request, data=data.encode("utf-8"))
+        rescode = response.getcode()
+        if(rescode==200):
+            response_body = response.read()
+            result = json.loads(response_body)
+            return result['message']['result']['translatedText']
+        else:
+            print("Error Code:" + rescode)
+
+    def ko_to_ja(word):
+        client_id = config.NAVER_CLIENT_ID
+        client_secret = config.NAVER_CLIENT_SECRET
+        encText = urllib.parse.quote(word)
+        data = "source=ko&target=ja&text=" + encText
+        url = "https://openapi.naver.com/v1/papago/n2mt"
+        request = urllib.request.Request(url)
+        request.add_header("X-Naver-Client-Id",client_id)
+        request.add_header("X-Naver-Client-Secret",client_secret)
+        response = urllib.request.urlopen(request, data=data.encode("utf-8"))
+        rescode = response.getcode()
+        if(rescode==200):
+            response_body = response.read()
+            result = json.loads(response_body)
+            return result['message']['result']['translatedText']
+        else:
+            print("Error Code:" + rescode)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from sksk_app import create_app, db
 from sksk_app.models import User, Level
 from sksk_app.utils.auth import UserManager
-import sksk_app.utils.edit as edit
+import sksk_app.utils.edit as editor
 
 @pytest.fixture()
 def app():
@@ -16,14 +16,35 @@ def app():
         level = 'ハン検5級'
         description = '입니다, 고 십다'
         position = 1
-        edit.LevelManager.add_level(level, description, position)
+        editor.LevelManager.add_level(level, description, position)
 
         level = 1
-        e_group = 'グループ1'
-        description = '입니다, 있다'
+        e_group = '指示詞、存在詞、数詞'
+        description = '입니다, 있다, 하나'
         position = 1
-        edit.E_GroupManager.add_e_group(level, e_group, description, position)
+        editor.E_GroupManager.add_e_group(level, e_group, description, position)
         
+        e_group = 1
+        element_name = '指示詞'
+        description = '입니다'
+        position = 1
+        editor.ElementManager.add_element(e_group, element_name, description, position)
+
+        element = 1
+        japanese = '父は医者です。'
+        foreign_l = '아버지는 의사입니다.'
+        style = 1
+        position = None
+        user = 1
+        editor.QuestionManager.add_question(element, japanese, foreign_l, style, position, user)
+
+        j_word = '医者'
+        f_word = '의사'
+        editor.WordManager.add_word(j_word, f_word)
+
+        question = 1
+        word = 1
+        editor.HintManager.add_hint(question, word)
 
         name = 'test'
         email = 'test@test.com'
@@ -34,8 +55,6 @@ def app():
         UserManager.add_privilege(1, 3)
         UserManager.add_privilege(1, 4)
         
-        db.session.begin_nested()
-
     yield app
 
 @pytest.fixture()

--- a/tests/utils/test_utils_edit.py
+++ b/tests/utils/test_utils_edit.py
@@ -1,52 +1,114 @@
 from sksk_app import db
-from sksk_app.models import Level, E_Group, Element, Question
+from sksk_app.models import Level, E_Group, Element, Question, Word, Hint
 import sksk_app.utils.edit as editor
 
 # LevelManager
 def test_add_level(app):
-    level_name = "ハン検4級"
-    description = "거예요, 아서, 러"
+    level_name = 'ハン検4級'
+    description = '거예요, 아서, 러'
     position = 3
     with app.app_context():
         editor.LevelManager.add_level(level_name,description, position)
-        level = Level.query.filter(Level.level==level_name)
+        level = Level.query.filter(Level.level==level_name).first()
     
-    assert level is not None
+    assert level.description == '거예요, 아서, 러'
 
 # E_GroupManager
 def test_add_e_group(app):
     level = 1
-    e_group_name = "グループ1"
-    description = "입나다, 고 십다"
+    e_group_name = "ハムニダ用言、助詞、否定"
+    description = "갑니다,에서,지 않다"
     position = None
     with app.app_context():
         editor.E_GroupManager.add_e_group(level, e_group_name, description, position)
-        e_group = E_Group.query.filter(E_Group.e_group==e_group_name)
+        e_group = E_Group.query.filter(E_Group.e_group==e_group_name).first()
 
-    assert e_group is not None
+    assert e_group.description == '갑니다,에서,지 않다'
 
 # ElementManager
 def test_add_element(app):
     e_group = 1
-    element_name = '指示詞'
-    description = '입니다'
+    element_name = '指示詞の否定'
+    description = '아닙니다'
     position = None
     with app.app_context():
         editor.ElementManager.add_element(e_group, element_name, description, position)
-        element = Element.query.filter(Element.element==element_name)
+        element = Element.query.filter(Element.element==element_name).first()
 
-    assert element is not None
+    assert element.description == '아닙니다'
 
 # QuestionManager
 def test_add_question(app):
     element = 1
-    japanese = '父は医者です。'
+    japanese = '私は学生です。'
     foreign_l = '저는 학생입니다.'
     style = 1
     position = None
     user = 1
     with app.app_context():
         editor.QuestionManager.add_question(element, japanese, foreign_l, style, position, user)
-        question = Question.query.filter(Question.japanese==japanese)
+        question = Question.query.filter(Question.japanese==japanese).first()
 
-    assert question is not None
+    assert question.foreign_l == '저는 학생입니다.'
+
+def test_fetch_questions_with_hints(app):
+    element = 1
+    with app.app_context():
+        questions = editor.QuestionManager.fetch_questions_with_hints(element)
+    
+    assert questions[0]['hint'][0].japanese == '医者'
+
+def test_fetch_question_with_hints(app):
+    question = 1
+    with app.app_context():
+        question = editor.QuestionManager.fetch_question_with_hints(question)
+
+    assert question['word'][0] == '父'
+
+#WordManager
+def test_add_word(app):
+    j_word = '父'
+    f_word = '아버지'
+    with app.app_context():
+        editor.WordManager.add_word(j_word, f_word)
+        word = Word.query.filter(Word.japanese==j_word).filter(Word.foreign_l==f_word).first()
+    assert word.foreign_l == '아버지'
+
+#HintManager  
+def test_fetch_word(app):
+    question = 1
+    word = 1
+    with app.app_context():
+        words = editor.HintManager.fetch_word(question)
+    
+    assert words[0].japanese == '医者'
+
+def test_confirm_j_hint(app):
+    question = 1
+    j_word = '医者'
+    with app.app_context():
+        existed = editor.HintManager.confirm_j_hint(question, j_word)
+
+    assert existed == 1
+
+def test_confirm_f_hint(app):
+    question = 1
+    f_word = '의사'
+    with app.app_context():
+        existed = editor.HintManager.confirm_f_hint(question, f_word)
+
+    assert existed == 1
+
+def test_add_hint(app):
+    question = 1
+    word = 1
+    with app.app_context():
+        editor.HintManager.add_hint(question, word)
+        hint = Hint.query.filter(Hint.question==1).first()
+    
+    assert hint.word == 1
+
+
+
+
+


### PR DESCRIPTION
Close #47

・日本語・外国語文を形態素解析し、単語だけ取り出し、
取り出した単語をクリックしていくだけで単語とヒントの追加ができるようになりました。
・既に登録済みの単語をヒントに追加する機能も追加すべき
・日本語の形態素解析にmecab-python3、韓国語はkonlpyを使用