### PR TITLE
次の項目の問題を連続で解く(ゲスト)

### DIFF
--- a/sksk_app/templates/account.html
+++ b/sksk_app/templates/account.html
@@ -1,0 +1,36 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h2>アカウント情報</h2>
+
+
+<table>
+    <tr>
+        <th>ユーザー名</th>
+        <td>{{session['user_name']}}</td>
+    </tr>
+    <tr>
+        <th>メールアドレス</th>
+        <td>{{user.email}}</td>
+    </tr>
+    <tr>
+        <th>今まで解いてきた問題数</th>
+        <td>{{all_count}} 問</td>
+    </tr>
+    <tr>
+        <th>全体の正答率</th>
+        <td>{{all_ratio}}</td>
+    </tr>
+    {% for grade_info in grades_info %}
+    <tr>
+        <th>{{grade_info.grade}}の消化率</th>
+        <td>{{grade_info.ratio}}</td>
+    </tr>
+    {% endfor %}
+</table>
+
+{{grades_info}}
+
+
+{% endblock %}

--- a/sksk_app/templates/guest/finish.html
+++ b/sksk_app/templates/guest/finish.html
@@ -9,7 +9,9 @@
 
 <p>トップページに戻る</p>
 
-<p>次の項目に進む</p>
+{% if next_element %}
+    <p><a href="{{url_for('guest.show_first_question', id = next_element.id)}}">次の項目({{next_element.element}})に進む</a></p>
+{% endif %}
 
 
 

--- a/sksk_app/views/guest.py
+++ b/sksk_app/views/guest.py
@@ -1,6 +1,6 @@
 from flask import Blueprint, redirect, url_for, render_template, request,session
-import numpy
 import math
+from sqlalchemy import not_
 
 from sksk_app import db
 from sksk_app.models import Grade, E_Group, Element, Question, Hint, Word
@@ -95,6 +95,12 @@ def finish():
 
     correct_ratio = math.floor((correct_answer/no)*100)
 
-    return render_template('guest/finish.html', no=no, correct_answer=correct_answer, correct_ratio=correct_ratio)
+    question = db.session.get(Question, questions[0][0])
+    element = db.session.get(Element, question.element)
+
+
+    next_element = Element.query.join(Question).filter(Element.e_group==element.e_group).filter(Element.position > question.position).filter(not_(Element.id==question.element)).filter(Question.released==1).first()
+
+    return render_template('guest/finish.html', no=no, correct_answer=correct_answer, correct_ratio=correct_ratio, next_element=next_element)
 
 


### PR DESCRIPTION
Close #62

ログインしないで問題を解いた場合の、一つの項目を全て解いた後、
「次の項目へ進む」を追加しました。
また、問題が公開されている項目だけ表示するように変更しました。