### PR TITLE
[update]単語の追加時に編集できるようにする

### DIFF
--- a/sksk_app/templates/edit/add_hint_edit_word.html
+++ b/sksk_app/templates/edit/add_hint_edit_word.html
@@ -1,0 +1,49 @@
+{%extends "base.html" %}
+{% block body %}
+
+<h2>ヒントの追加</h2>
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+<p>単語の編集を行います。</p>
+
+<form action="{{url_for('edit.add_word_hint')}}" method="POST">
+
+<table>
+    <tr>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td>
+            <input type="text" name="japanese_word" value="{{japanese_word}}">
+        </td>
+        <td>
+            <input type="text" name="foreign_word" value="{{foreign_word}}">
+        </td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    <tr>
+        <td>{{question.id}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+    </tr>
+</table>
+
+    <input type="hidden" name="question_id" value="{{question.id}}">
+    <button type="button" onclick="history.back()">戻る</button>
+    <button>確認</button>
+</form>
+
+
+
+<p><a href="{{url_for('edit.show_hints', e=question.element)}}">問題一覧に戻る</a></p>
+
+
+{% endblock %}

--- a/sksk_app/templates/edit/add_word_hint.html
+++ b/sksk_app/templates/edit/add_word_hint.html
@@ -8,14 +8,46 @@
 
 <table>
     <tr>
+        <th></th>
         <th>日本語</th>
         <th>韓国語</th>
     </tr>
     <tr>
-        <td>{{j_word}}</td>
-        <td>{{f_word}}</td>
+        <th></th>
+        <td>{{japanese_word}}</td>
+        <td>{{foreign_word}}</td>
+    </tr>
+    <tr>
+        <th>翻訳</th>
+        <td>{{ko_to_ja}}</td>
+        <td>{{ja_to_ko}}</td>
+    </tr>
+    <tr>
+        <th>判定</th>
+        <td>
+            {% if japanese_word == ko_to_ja %}
+            ○
+            {% else %}
+            ×
+            {% endif %}
+        </td>
+        <td>
+            {% if foreign_word == ja_to_ko %}
+            ○
+            {% else %}
+            ×
+            {% endif %}
+        </td>
     </tr>
 </table>
+<div class="flex">
+<form action="{{url_for('edit.add_word_hint_edit')}}" method="POST">
+    <input type="hidden" name="question_id" value="{{question.id}}">
+    <input type="hidden" name="japanese_word" value="{{japanese_word}}">
+    <input type="hidden" name="foreign_word" value="{{foreign_word}}">
+    <button>編集</button>
+</form>
+</div>
 
 <table>
     <tr>
@@ -32,8 +64,8 @@
 
 <form action="{{url_for('edit.add_word_hint_execute')}}" method="POST">
     <input type="hidden" name="question_id" value="{{question.id}}">
-    <input type="hidden" name="j_word" value="{{j_word}}">
-    <input type="hidden" name="f_word" value="{{f_word}}">
+    <input type="hidden" name="japanese_word" value="{{japanese_word}}">
+    <input type="hidden" name="foreign_word" value="{{foreign_word}}">
     <button type="button" onclick="history.back()">戻る</button>
     <button>追加</button>
 </form>

--- a/sksk_app/templates/edit/confirm_hint_f.html
+++ b/sksk_app/templates/edit/confirm_hint_f.html
@@ -7,12 +7,12 @@
 
 <table>
     <tr>
-        <th>日本語</th>
-        <th>韓国語(候補)</th>
+        <th>日本語(候補)</th>
+        <th>韓国語</th>
     </tr>
     <tr>
-        <td>{{f_word}}</td>
         <td>{{translated_word}}</td>
+        <td>{{foreign_word}}</td>
     </tr>
 </table>
 
@@ -33,8 +33,8 @@
             {% for word in question['word'] %}
             <form action="{{url_for('edit.add_word_hint')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="j_word" value="{{word}}">
-                <input type="hidden" name="f_word" value="{{f_word}}">
+                <input type="hidden" name="japanese_word" value="{{japanese_word}}">
+                <input type="hidden" name="foreign_word" value="{{foreign_word}}">
                 <button>{{word}}</button>
             </form>
             {% endfor %}
@@ -46,7 +46,7 @@
             {% if not foword == '.' %}
             <form action="{{url_for('edit.confirm_hint_f')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="f_word" value="{{foword}}">
+                <input type="hidden" name="foreign_word" value="{{foreign_word}}">
                 <button>{{foword}}</button>
             </form>
             {% else %}
@@ -100,10 +100,10 @@
     </tr>
 {% for f_word in f_words %}
 <tr>
-    <td>{{f_word['id']}}</td>
-    <td>{{f_word['japanese']}}</td>
-    <td>{{f_word['foreign_l']}}</td>
-    <td><a href="{{url_for('edit.add_hint', q= question.id, w=f_word['id'])}}">追加する</a></td>
+    <td>{{foreign_word['id']}}</td>
+    <td>{{foreign_word['japanese']}}</td>
+    <td>{{foreign_word['foreign_l']}}</td>
+    <td><a href="{{url_for('edit.add_hint', q= question.id, w=foreign_word['id'])}}">追加する</a></td>
 </tr>
 {% endfor %}
 {% if not f_words[0] %}

--- a/sksk_app/templates/edit/confirm_hint_j.html
+++ b/sksk_app/templates/edit/confirm_hint_j.html
@@ -11,8 +11,16 @@
         <th>韓国語(候補)</th>
     </tr>
     <tr>
-        <td>{{j_word}}</td>
-        <td>{{translated_word}}</td>
+        <td>{{japanese_word}}</td>
+        <td>{{translated_word}}
+            <form action="{{url_for('edit.add_word_hint')}}" method="POST">
+                <input type="hidden" name="question_id" value="{{question.id}}">
+                <input type="hidden" name="japanese_word" value="{{japanese_word}}">
+                <input type="hidden" name="foreign_word" value="{{translated_word}}">
+                <button>追加する</button>
+            </form>
+
+        </td>
     </tr>
 </table>
 
@@ -30,24 +38,24 @@
     <tr>
         <td>
             <div class="flex">
-            {% for word in question['word'] %}
+            {% for japanese_word in question['japanese_word'] %}
             <form action="{{url_for('edit.confirm_hint_j')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="j_word" value="{{word}}">
-                <button>{{word}}</button>
+                <input type="hidden" name="japanese_word" value="{{japanese_word}}">
+                <button>{{japanese_word}}</button>
             </form>
             {% endfor %}
             </div>
         </td>
         <td>
             <div class="flex">
-            {% for foword in question['foword'] %}
+            {% for foreign_word in question['foreign_word'] %}
             {% if not foword == '.' %}
             <form action="{{url_for('edit.add_word_hint')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="j_word" value="{{j_word}}"> 
-                <input type="hidden" name="f_word" value="{{foword}}">
-                <button>{{foword}}</button>
+                <input type="hidden" name="japanese_word" value="{{japanese_word}}"> 
+                <input type="hidden" name="foreign_word" value="{{foreign_word}}">
+                <button>{{foreign_word}}</button>
             </form>
             {% else %}
             {% endif %}
@@ -71,7 +79,7 @@
     </tr>
     {% for word in words %}
     <tr>
-        {% if j_word == word['japanese'] %}
+        {% if japanese_word == word['japanese'] %}
         <td style="color:red">{{word['japanese']}}</td>
         {% else %}
         <td>{{word['japanese']}}</td>
@@ -95,15 +103,15 @@
         <th>韓国語</th>
         <th>操作</th>
     </tr>
-{% for j_word in j_words %}
+{% for japanese_word in japanese_words %}
 <tr>
-    <td>{{j_word['id']}}</td>
-    <td>{{j_word['japanese']}}</td>
-    <td>{{j_word['foreign_l']}}</td>
-    <td><a href="{{url_for('edit.add_hint', q=question.id, w=j_word['id'])}}">追加する</td>
+    <td>{{japanese_word['id']}}</td>
+    <td>{{japanese_word['japanese']}}</td>
+    <td>{{japanese_word['foreign_l']}}</td>
+    <td><a href="{{url_for('edit.add_hint', q=question.id, w=japanese_word['id'])}}">追加する</td>
 </tr>
 {% endfor %}
-{% if not j_words[0] %}
+{% if not japanese_words[0] %}
 <tr>
     <td colspan="4">登録単語なし</td>
 </tr>

--- a/sksk_app/templates/edit/show_hints.html
+++ b/sksk_app/templates/edit/show_hints.html
@@ -5,7 +5,7 @@
 
 
 <p><a href="{{url_for('edit.show')}}">レベル・項目グループ・項目の登録</a></p>
-<p><a href="{{url_for('edit.show_questions')}}">問題文の登録</a></p>
+<p><a href="{{url_for('edit.show_questions', e=element.id)}}">問題文の登録</a></p>
 
 <div class="flex">
     <select name="grade" id="grade" onchange="location.href=value">
@@ -51,7 +51,7 @@
             {%for word in question['word'] %}
             <form action="{{url_for('edit.confirm_hint_j')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="j_word" value="{{word}}">
+                <input type="hidden" name="japanese_word" value="{{word}}">
                 <button>{{word}}</button>
             </form>
             {% endfor %}
@@ -63,7 +63,7 @@
             {% if not foword == '.' %}
             <form action="{{url_for('edit.confirm_hint_f')}}" method="POST">
                 <input type="hidden" name="question_id" value="{{question.id}}">
-                <input type="hidden" name="f_word" value="{{foword}}">
+                <input type="hidden" name="foreign_word" value="{{foreign_word}}">
                 <button>{{foword}}</button>
             </form>
             {% else %}

--- a/sksk_app/templates/edit/show_questions.html
+++ b/sksk_app/templates/edit/show_questions.html
@@ -5,7 +5,7 @@
 
 
 <p><a href="{{url_for('edit.show')}}">レベル・項目グループ・項目の登録</a></p>
-<p><a href="{{url_for('edit.show_hints')}}">ヒントの登録</a></p>
+<p><a href="{{url_for('edit.show_hints', e=element.id)}}">ヒントの登録</a></p>
 
 <div class="flex">
     <select name="grade" id="grade" onchange="location.href=value">

--- a/sksk_app/utils/edit.py
+++ b/sksk_app/utils/edit.py
@@ -335,27 +335,27 @@ class QuestionManager:
             'japanese':question.japanese,
             'foreign_l':question.foreign_l,
             'element':question.element,
-            'word':None,
-            'foword':None,
+            'japanese_word':None,
+            'foreign_word':None,
             'hint':None
         }
         mecab = MeCab.Tagger()
         # 単語の候補
-        question_with_hints['word']= []
+        question_with_hints['japanese_word']= []
         node = mecab.parseToNode(question_with_hints['japanese'])
         while node:
             p = node.feature.split(',')[0]
             if p == '名詞' or p == '動詞' or p== '形容詞' or p =='副詞':
-                question_with_hints['word'].append(node.feature.split(",")[6])
+                question_with_hints['japanese_word'].append(node.feature.split(",")[6])
             node = node.next
 
         # 韓国語のそれぞれの単語
-        question_with_hints['foword'] = []
+        question_with_hints['foreign_word'] = []
         text = question_with_hints['foreign_l']
         okt = Okt()
         korean_w = okt.morphs(text, norm=True, stem=True)
         for word in korean_w:
-            question_with_hints['foword'].append(word)
+            question_with_hints['foreign_word'].append(word)
 
 
         # 登録済みのヒント
@@ -429,10 +429,10 @@ class QuestionManager:
 
 class WordManager:
 
-    def add_word(j_word, f_word):
+    def add_word(japanese_word, foreign_word):
         new_word = Word(
-            japanese = j_word,
-            foreign_l = f_word
+            japanese = japanese_word,
+            foreign_l = foreign_word
         )
 
         db.session.add(new_word)
@@ -451,22 +451,22 @@ class HintManager:
 
         return words
 
-    def confirm_j_hint(question, j_word):
+    def confirm_j_hint(question, japanese_word):
         hints = Hint.query.filter(Hint.question==question)
         existed = 0
         for hint in hints:
             word = db.session.get(Word, hint.word)
-            if j_word in word.japanese:
+            if japanese_word in word.japanese:
                 existed += 1
         
         return existed
     
-    def confirm_f_hint(question, f_word):
+    def confirm_f_hint(question, foreign_word):
         hints = Hint.query.filter(Hint.question==question)
         existed = 0
         for hint in hints:
             word = db.session.get(Word, hint.word)
-            if f_word in word.foreign_l:
+            if foreign_word in word.foreign_l:
                 existed += 1
         
         return existed

--- a/sksk_app/views/edit.py
+++ b/sksk_app/views/edit.py
@@ -803,16 +803,16 @@ def delete_question_done():
 @login_required
 def confirm_hint_j():
     question_id = request.form['question_id']
-    j_word = request.form['j_word']
+    japanese_word = request.form['japanese_word']
     question_with_hints = editor.QuestionManager.fetch_question_with_components_hints(question_id)
 
-    j_words = Word.query.filter(Word.japanese.like("%" + j_word + "%"))
-    translated_word = api.Papago.ja_to_ko(j_word)
+    japanese_words = Word.query.filter(Word.japanese.like("%" + japanese_word + "%"))
+    translated_word = api.Papago.ja_to_ko(japanese_word)
 
     words = editor.HintManager.fetch_word(question_id)
-    hint_existed = editor.HintManager.confirm_j_hint(question_id, j_word)
+    hint_existed = editor.HintManager.confirm_j_hint(question_id, japanese_word)
 
-    return render_template('edit/confirm_hint_j.html', question=question_with_hints, j_word=j_word, j_words=j_words, translated_word=translated_word, words=words, hint_existed=hint_existed)
+    return render_template('edit/confirm_hint_j.html', question=question_with_hints, japanese_word=japanese_word, japanese_words=japanese_words, translated_word=translated_word, words=words, hint_existed=hint_existed)
 
 @edit.route('/confirm/hint/f', methods=['POST'])
 @login_required
@@ -833,21 +833,23 @@ def confirm_hint_f():
 @login_required
 def add_word_hint():
     question_id = request.form['question_id']
-    j_word = request.form['j_word']
-    f_word = request.form['f_word']
+    japanese_word = request.form['japanese_word']
+    foreign_word = request.form['foreign_word']
     question_with_hints = editor.QuestionManager.fetch_question_with_components_hints(question_id)
+    ja_to_ko = api.Papago.ja_to_ko(japanese_word)
+    ko_to_ja = api.Papago.ko_to_ja(foreign_word)
 
-    return render_template('edit/add_word_hint.html', question = question_with_hints, j_word=j_word, f_word=f_word)
+    return render_template('edit/add_word_hint.html', question = question_with_hints, japanese_word=japanese_word, foreign_word=foreign_word, ja_to_ko=ja_to_ko, ko_to_ja=ko_to_ja)
 
 @edit.route('/add/word/hint_addded', methods=['POST'])
 @login_required
 def add_word_hint_execute():
     question_id = request.form['question_id']
-    j_word = request.form['j_word']
-    f_word = request.form['f_word']
+    japanese_word = request.form['japanese_word']
+    foreign_word = request.form['foreign_word']
 
-    editor.WordManager.add_word(j_word, f_word)
-    word_id = Word.query.filter(Word.japanese==j_word).filter(Word.foreign_l==f_word).first().id
+    editor.WordManager.add_word(japanese_word, foreign_word)
+    word_id = Word.query.filter(Word.japanese==japanese_word).filter(Word.foreign_l==foreign_word).first().id
     editor.HintManager.add_hint(question_id, word_id)
     question = db.session.get(Question, question_id)
     element = db.session.get(Element, question.element)
@@ -892,3 +894,13 @@ def add_hint_done():
     return redirect(url_for('edit.show_hints', e=element_id))
 
 
+@edit.route('/add/word/hint/edit', methods=['POST'])
+@login_required
+def add_word_hint_edit():
+    question_id = request.form['question_id']
+    japanese_word = request.form['japanese_word']
+    foreign_word = request.form['foreign_word']
+
+    question = db.session.get(Question, question_id)
+
+    return render_template('edit/add_hint_edit_word.html', question=question, japanese_word=japanese_word, foreign_word=foreign_word)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,9 +58,9 @@ def app():
         editor.QuestionManager.add_question(element, level, japanese, foreign_l, style, spoken, sida, will, user)
 
 
-        j_word = '医者'
-        f_word = '의사'
-        editor.WordManager.add_word(j_word, f_word)
+        japanese_word = '医者'
+        foreign_word = '의사'
+        editor.WordManager.add_word(japanese_word, foreign_word)
 
         question = 1
         word = 1

--- a/tests/utils/test_utils_edit.py
+++ b/tests/utils/test_utils_edit.py
@@ -135,7 +135,7 @@ def test_fetch_question_with_components_hints(app):
     with app.app_context():
         question = editor.QuestionManager.fetch_question_with_components_hints(question)
 
-    assert question['word'][0] == '父'
+    assert question['japanese_word'][0] == '父'
 
 def test_fetch_question_with_hints(app):
     question = 1
@@ -154,11 +154,11 @@ def test_fetch_attribute(app):
 
 #WordManager
 def test_add_word(app):
-    j_word = '父'
-    f_word = '아버지'
+    japanese_word = '父'
+    foreign_word = '아버지'
     with app.app_context():
-        editor.WordManager.add_word(j_word, f_word)
-        word = Word.query.filter(Word.japanese==j_word).filter(Word.foreign_l==f_word).first()
+        editor.WordManager.add_word(japanese_word, foreign_word)
+        word = Word.query.filter(Word.japanese==japanese_word).filter(Word.foreign_l==foreign_word).first()
     assert word.foreign_l == '아버지'
 
 #HintManager  


### PR DESCRIPTION
Close #97

単語を登録する際、日本語及び外国語の編集ができるようにしました。
また、日本語の単語から翻訳された韓国語を、そのまま登録できるようにしました。

j_word,f_wordをjapanese_word, foreign_wordに変更しました。
f_wordだと誤解を招くことを考慮しました。