### PR TITLE
[update]確認依頼の削除

### DIFF
--- a/sksk_app/templates/request/delete_check_request.html
+++ b/sksk_app/templates/request/delete_check_request.html
@@ -1,0 +1,52 @@
+{% extends "base.html" %}
+
+{% block body %}
+
+<h2>確認依頼の削除</h2>
+
+<p>以下の確認依頼を削除しますか？</p>
+
+<form action="{{url_for('req.delete_check_request_execute')}}" method="POST">
+<table>
+    <tr>
+        <th>id</th>
+        <td>{{request.id}}</td>
+    </tr>
+    <tr>
+        <th>タイトル</th>
+        <td>{{request.title}}</td>
+    </tr>
+    <tr>
+        <th>詳細</th>
+        <td>{{request.detail}}</td>
+    </tr>
+    <tr>
+        <th>依頼日時</th>
+        <td>{{request.requested_at}}</td>
+    </tr>
+</table>
+
+<table>
+    <tr>
+        <th>id</th>
+        <th>級</th>
+        <th>項目</th>
+        <th>日本語</th>
+        <th>韓国語</th>
+    </tr>
+    {% for question in questions %}
+    <tr>
+        <td>{{question.id}}</td>
+        <td>{{question.grade}}</td>
+        <td>{{question.element}}</td>
+        <td>{{question.japanese}}</td>
+        <td>{{question.foreign_l}}</td>
+    </tr>
+    {% endfor %}
+</table>
+<input type="hidden" name="request_id" value="{{request.id}}">
+<button>削除</button>
+<button type="button" onclick="history.back()">戻る</button>
+</form>
+
+{% endblock %}

--- a/sksk_app/templates/request/requested_questions.html
+++ b/sksk_app/templates/request/requested_questions.html
@@ -32,6 +32,10 @@
     {% endif %}
 </table>
 
+{% if session['edit'] and request.finished_at == None %}
+<p><a href="{{url_for('req.delete_check_request', r= request.id)}}">この確認依頼を削除する</a></p>
+{% endif %}
+
 <h3>依頼した問題文</h3>
 {% if session['check'] and request.finished_at == None%}
 修正の必要ないものは「確認」にチェックをお願いします。

--- a/sksk_app/utils/request.py
+++ b/sksk_app/utils/request.py
@@ -65,6 +65,7 @@ class RequestManager:
 
         return questions
 
+    # 確認依頼
     def add_request(questions_requested, title, detail, user_id):
         now = datetime.now()
 
@@ -91,6 +92,20 @@ class RequestManager:
 
             question = db.session.get(Question, question_requested)
             question.process = 4
+            db.session.merge(question)
+            db.session.commit()
+
+    def delete_request(request_id):
+
+        question_request = db.session.get(Question_Request, request_id)
+        question_request.process = 3
+        db.session.merge(question_request)
+        db.session.commit()
+
+        requested_questions = Question.query.join(Requested_Question).filter(Requested_Question.request_id==request_id)
+        for requested_question in requested_questions:
+            question = db.session.get(Question, requested_question.id)
+            question.process = 2
             db.session.merge(question)
             db.session.commit()
 

--- a/sksk_app/views/request.py
+++ b/sksk_app/views/request.py
@@ -122,3 +122,27 @@ def question_checked_execute():
 def question_checked_done():
     flash('問題文の確認を行いました。')
     return redirect(url_for('req.index'))
+
+@req.route('/delete/check_request')
+@login_required
+def delete_check_request():
+    request_id = request.args.get('r')
+    question_request = db.session.get(Question_Request, request_id)
+    questions = RequestManager.fetch_questions_with_check_message(request_id)
+
+    return render_template('request/delete_check_request.html', request=question_request, questions=questions)
+
+@req.route('/delete/check_request_deleted', methods=['POST'])
+@login_required
+def delete_check_request_execute():
+    request_id = request.form['request_id']
+    RequestManager.delete_request(request_id)
+
+    return redirect(url_for('req.delete_check_request_done'))
+
+@req.route('/delete/check_request_deleted')
+@login_required
+def delete_check_request_done():
+    flash('確認依頼を削除しました。')
+    return redirect(url_for('req.index'))
+


### PR DESCRIPTION
Close #108

編集者が作成した確認依頼を、削除できるようにしました。
実際はquestion_requestのprocessを3（削除）にし、レコード自体は削除していません。
（このやり方を問題文にも適応します。）