### PR TITLE
[fix]問題出題画面で文体などのヒントの表示

### DIFF
--- a/sksk_app/static/style.css
+++ b/sksk_app/static/style.css
@@ -601,3 +601,17 @@ section {
   width:300px;
   padding:10px;
 }
+.question-attribute {
+  width:310px;
+  margin:5px;
+  margin-top:20px;
+}
+
+.question-attribute span{
+  color:var(--text);
+  background-color:var(--primary);
+  font-size:1em;
+  font-family: 'Kaisei Decol', serif;
+  padding:10px 7px;
+  border-radius:7px;
+}

--- a/sksk_app/templates/approve/approved_questions.html
+++ b/sksk_app/templates/approve/approved_questions.html
@@ -32,7 +32,6 @@
     {% endfor %}
 </table>
 <div class="right">
-    <button class="back" type="button" onclick="history.back()">戻る</button>
     <button class="add">非公開にする</button>
 </div>
 </form>

--- a/sksk_app/templates/approve/not_approved_questions.html
+++ b/sksk_app/templates/approve/not_approved_questions.html
@@ -48,7 +48,6 @@
     {% endfor %}
 </table>
 <div class="right">
-    <button class="back" type="button" onclick="history.back()">戻る</button>
     <button class="add">公開する</button>
 </div>
 </form>

--- a/sksk_app/templates/edit/add_element.html
+++ b/sksk_app/templates/edit/add_element.html
@@ -10,13 +10,11 @@
         <th>項目グループ</th>
         <th>項目</th>
         <th>説明</th>
-        <th>項番</th>
     </tr>
     <tr>
         <td>{{e_group_name}}</td>
         <td>{{element.element}}</td>
         <td>{{element.description}}</td>
-        <td>{{element.position}}</td>
     </tr>
 </table>
 
@@ -24,7 +22,6 @@
     <input type="hidden" name="e_group" value="{{element.e_group}}">
     <input type="hidden" name="element_name" value="{{element.element}}">
     <input type="hidden" name="description" value="{{element.description}}">
-    <input type="hidden" name="position" value="{{element.position}}">
 <div class="right">
     <button class="back" type="button" onclick="history.back()">戻る</button>
     <button class="add">追加</button>

--- a/sksk_app/templates/edit/show_questions.html
+++ b/sksk_app/templates/edit/show_questions.html
@@ -75,7 +75,8 @@
             {% endif %}
         </td>
         <td>
-            {% if question.process == 5 or question.process == 8 %}
+            {% if question.audio %}
+            {% else %}
             <form>
             <input type="checkbox" class="checks" name="question" value="{{question.id}}">
             {% endif %}

--- a/sksk_app/templates/question/question.html
+++ b/sksk_app/templates/question/question.html
@@ -18,6 +18,21 @@
 <p>{{question.japanese}}</p>
 </div>
 
+<div class="question-attribute">
+    <span>{{question.style}}</span>
+    {%if question.spoken %}
+    <span>口語</span>
+    {% endif %}
+    {%if question.sida %}
+    <span>시다</span>
+    {% endif %}
+    {%if question.will %}
+    <span>겠</span>
+    {% endif %}
+</div>
+
+
+
 <div id="after_button">
 
 <div class="hint">

--- a/sksk_app/templates/request/index.html
+++ b/sksk_app/templates/request/index.html
@@ -66,6 +66,7 @@
             {% elif request.condition == 2 %}
             再提出済み
             {% endif %}
+            
         </td>
     </tr>
     {% endfor %}

--- a/sksk_app/templates/request/requested_questions.html
+++ b/sksk_app/templates/request/requested_questions.html
@@ -55,10 +55,6 @@
         {% if session['check']%}
         <th>確認</th>
         {% endif %}
-        {% if session['approve'] and request.finished_at %}
-        <th>公開<br>
-            <label><input type="checkbox" id="checkAll" name="question">全て選択</label></th>
-        {% endif %}
     </tr>
     {% for question in questions %}
     <tr>
@@ -76,11 +72,6 @@
         {% if request.finished_at %}
         <td rowspan="2">
             {{question.checked}}
-        </td>
-        {% endif %}
-        {% if session['approve'] and request.finished_at %}
-        <td rowspan="2"> 
-            <input type="checkbox" class="checks" name="question" value="{{question.id}}">
         </td>
         {% endif %}
     </tr>
@@ -115,10 +106,6 @@
 </form>
 {% endif %}
 
-{% if session['approve'] and request.finished_at %}
-<button formaction="" formmethod="">公開</button>
-<button type="button" onclick="history.back()">戻る</button>
-{% endif %}
 
 {% if session['edit'] and rejected_questions and request.request_id == 0 %}
 <div class="right">

--- a/sksk_app/utils/edit.py
+++ b/sksk_app/utils/edit.py
@@ -376,12 +376,18 @@ class QuestionManager:
     
     def fetch_question_with_hints(question_id):
         question = db.session.get(Question, question_id)
+        style = db.session.get(Style, question.style)
         question_with_hints = {
             'id': int(question.id),
             'japanese':question.japanese,
             'foreign_l':question.foreign_l,
             'element':question.element,
-            'hint':None
+            'hint':None,
+            'style_id':question.style,
+            'style':style.style,
+            'spoken':question.spoken,
+            'sida':question.sida,
+            'will':question.will
         }
 
         # 登録済みのヒント

--- a/sksk_app/utils/request.py
+++ b/sksk_app/utils/request.py
@@ -120,8 +120,8 @@ class RequestManager:
             rejected_questions = RequestManager.search_rejected_question(request_done_raw.id)
             if rejected_questions:
                 condition = 1
-                resubmit = Question_Request.query.filter(Question_Request.request_id!=0).first()
-                if resubmit:
+                resubmit = Question_Request.query.filter(Question_Request.id==request_done_raw.id).filter(Question_Request.request_id==0).first()
+                if not resubmit:
                     condition = 2
             
             request_done = {

--- a/sksk_app/views/question.py
+++ b/sksk_app/views/question.py
@@ -80,6 +80,7 @@ def show_first_question():
         session['questions'] = questions
 
 
+
     questions = session.get('questions')
 
     question = editor.QuestionManager.fetch_question_with_hints(questions[0][0])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -66,6 +66,18 @@ def app():
         word = 1
         editor.HintManager.add_hint(question, word)
 
+
+        style = 'ハムニダ体'
+        editor.StyleManager.add_style(style)
+        style = 'ヘヨ体'
+        editor.StyleManager.add_style(style)
+        style = 'ヘ体'
+        editor.StyleManager.add_style(style)
+        style = 'ハンダ体'
+        editor.StyleManager.add_style(style)
+        style = 'ハオ体'
+        editor.StyleManager.add_style(style)
+
         name = 'test'
         email = 'test@test.com'
         password = '1234'


### PR DESCRIPTION
Close #154

「ハムニダ体」「ヘヨ体」などの文体、
口語、敬語、意志が含まれるかを問題出題画面に表示するようにしました。