### PR TITLE
[fix]ログイン時ユーザーが存在しないことの通知

### DIFF
--- a/sksk_app/utils/user.py
+++ b/sksk_app/utils/user.py
@@ -11,8 +11,12 @@ class LoginManager:
     def login(email, password):
 
         user = User.query.filter_by(email=email).first()
+
+        if not user:
+            flash('Eメールアドレスが登録されていません')
+            return redirect(url_for('auth.login'))
         
-        if not user or not check_password_hash(user.password, password):
+        if not check_password_hash(user.password, password):
             flash('パスワードが異なります')
             return redirect(url_for('auth.login'))
 


### PR DESCRIPTION
Close #167

登録されていないメールアドレスでログインしようとした時、
「Eメールアドレスが登録されていません」と表示するようにしました。