### PR TITLE
[fix]問題出題画面の音声再生ボタンの修正

### DIFF
--- a/sksk_app/static/style.css
+++ b/sksk_app/static/style.css
@@ -316,6 +316,7 @@ section {
 .audio  {
   font-size:1.3em;
   font-family: 'Kaisei Decol', serif;
+  height:60px;
   color:#ffffff;
   background-color: var(--text);
   border:0;

--- a/sksk_app/templates/question/question.html
+++ b/sksk_app/templates/question/question.html
@@ -76,7 +76,6 @@
             <div class="answer">
             <p>{{question.foreign_l}}</p>
             </div>
-            
 
             <div class="audio-button">
                 <div class="audio mb-2 text-center" onclick="audio()"><img src="{{url_for('static', filename='images/play.png')}}" alt="再生" width="40"></div>


### PR DESCRIPTION
高さを設定し、読み込み後のズレを無くしました。

Close #201